### PR TITLE
Fix useStoreState condition for triggering re-renders

### DIFF
--- a/src/use_store_state.ts
+++ b/src/use_store_state.ts
@@ -663,7 +663,7 @@ export function useStoreState<ST extends Store<any>>(
         newSubset === undefined ||
         subsetRef.current === undefined ||
         newSubset.length !== subsetRef.current.length ||
-        newSubset.some((v, i) => !subsetRef.current[i] !== v)
+        newSubset.some((v, i) => subsetRef.current[i] !== v)
       ) {
         subsetRef.current = newSubset;
         reRender(Date.now());

--- a/src/use_store_state.ts
+++ b/src/use_store_state.ts
@@ -663,7 +663,7 @@ export function useStoreState<ST extends Store<any>>(
         newSubset === undefined ||
         subsetRef.current === undefined ||
         newSubset.length !== subsetRef.current.length ||
-        newSubset.findIndex(v => !subsetRef.current.includes(v)) > -1
+        newSubset.some((v, i) => !subsetRef.current[i] !== v)
       ) {
         subsetRef.current = newSubset;
         reRender(Date.now());


### PR DESCRIPTION
Listeners would not re-render if the previous subset included a certain value of the new subset anywhere in the array.

**Example:**
old: [1, 2, 3, 4]
new: [1, 2, 3, 1]
would not re-render since the value 1 is found at index 0 of the previous subset.